### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,7 +203,7 @@ jobs:
         snap: ${{ steps.snap_build.outputs.snap }}
         release: ${{ steps.collect_assets.outputs.snap_channel }}
     - name: Docker build push
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}
         tags: ${{ steps.collect_assets.outputs.docker_tags }}
@@ -211,7 +211,7 @@ jobs:
         username: ${{ secrets.DOCKER_USR }}
         no_push: ${{ steps.collect_assets.outputs.docker_tags == '' }}
     - name: Docker push GitHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}/tqdm
         tags: ${{ steps.collect_assets.outputs.docker_tags }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore